### PR TITLE
Ensure output is posted to console after child process finishes

### DIFF
--- a/lib/paramedic.js
+++ b/lib/paramedic.js
@@ -346,8 +346,18 @@ ParamedicRunner.prototype.runLocalTests = function () {
         if (!self.config.getPlatformId() === util.BROWSER) {
             return execPromise(command);
         }
-        runProcess = cp.exec(command, function () {
-            // a precaution not to try to kill some other process
+        // We do not wait for the child process to finish, server connects when deployed and ready. 
+        runProcess = cp.exec(command, (error, stdout, stderr) => {     
+            if (error) {
+                // This won't show up until the process completes:
+                console.log('[ERROR]: Running cordova run failed');
+
+                console.log(stdout);
+                console.log(stderr);
+                reject(error);
+            }
+            console.log(stdout);
+            console.log(stderr);
             runProcess = null;
         });
     })


### PR DESCRIPTION
Child process output is not visible in the console unless handled explicitly. This hides errors from cordova run xxx making it impossible to detect build errors.