### PR TITLE
device is real device, not emulator with device tag

### DIFF
--- a/lib/utils/utilities.js
+++ b/lib/utils/utilities.js
@@ -29,7 +29,7 @@ var kill    = require('tree-kill');
 
 var HEADING_LINE_PATTERN = /List of devices/m;
 var DEVICE_ROW_PATTERN   = /(emulator|device|host)/m;
-var DEVICE_ONLY_ROW_PATTERN   = /(device)/m;
+var DEVICE_ONLY_ROW_PATTERN   = /(^(?!.*(emulator)).*device.*$)/m;
 
 var KILL_SIGNAL = 'SIGINT';
 


### PR DESCRIPTION
Improve regex to filter out devices with emulator as part of the name